### PR TITLE
gitian-building: add extra macOS Xcode dependency

### DIFF
--- a/gitian-building.md
+++ b/gitian-building.md
@@ -94,6 +94,7 @@ wget -P inputs https://bitcoincore.org/cfields/osslsigncode-Backports-to-1.7.1.p
 wget -O osslsigncode-2.0.tar.gz -P inputs https://github.com/mtrojnar/osslsigncode/archive/2.0.tar.gz
 wget -P inputs https://downloads.sourceforge.net/project/osslsigncode/osslsigncode/osslsigncode-1.7.1.tar.gz
 wget -P inputs https://bitcoincore.org/depends-sources/sdks/MacOSX10.14.sdk.tar.gz
+wget -P inputs https://bitcoincore.org/depends-sources/sdks/Xcode-11.3.1-11C505-extracted-SDK-with-libcxx-headers.tar.gz
 popd
 ```
 


### PR DESCRIPTION
I had to download this additional library to get the macOS build working.
I'm not sure if the `MacOSX10.14.sdk.tar.gz` is still needed or is being replaced by the `Xcode` dependency.