### PR TITLE
blocked port for apt-cacher-ng

### DIFF
--- a/gitian-building.md
+++ b/gitian-building.md
@@ -106,7 +106,12 @@ bin/make-base-vm --suite bionic --arch amd64 --docker
 popd
 ```
 
-If you encounter an error about connection timeouts on 172.17.0.1:3142, you probably have blocked port 3142 for apt-cacher-ng.
+If you encounter an error about connection timeouts and you are running a firewall like UFW, you have likely blocked port 3142. Open port 3142, which is required for apt-cacher-ng's web server:
+
+```bash
+ufw allow 3142/tcp
+ufw reload
+```
 
 ## Set up and check out the branches to build
 

--- a/gitian-building.md
+++ b/gitian-building.md
@@ -106,6 +106,8 @@ bin/make-base-vm --suite bionic --arch amd64 --docker
 popd
 ```
 
+If you encounter an error about connection timeouts on 172.17.0.1:3142, you probably have blocked port 3142 for apt-cacher-ng.
+
 ## Set up and check out the branches to build
 
 You can run the following `git tag` command from within your local bitcoin


### PR DESCRIPTION
## Description
I encountered an error message about connection timeouts on 172.17.0.1:3142 during the making of the base VM.

```bash
 ---> Running in XXXXXXX
Err:1 http://archive.ubuntu.com/ubuntu xenial InRelease
  Could not connect to 172.17.0.1:3142 (172.17.0.1), connection timed out
Err:2 http://security.ubuntu.com/ubuntu xenial-security InRelease
  Could not connect to 172.17.0.1:3142 (172.17.0.1), connection timed out
Err:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
  Unable to connect to 172.17.0.1:3142:
Err:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
  Unable to connect to 172.17.0.1:3142:
```
The reason was a blocked port 3142 on my system.

## Solution
Open the port in the UFW as described in this [tutorial](https://kifarunix.com/how-to-setup-apt-caching-server-using-apt-cacher-ng-on-ubuntu-18-04/).

```bash
ufw allow 3142/tcp
ufw reload
```

## How Has This Been Tested?
Yes, on Ubuntu 20.04.1 LTS (Focal Fossa).