### PR TITLE
(Fix) broken tarballs download to inputs dir

### DIFF
--- a/gitian-building.md
+++ b/gitian-building.md
@@ -110,7 +110,7 @@ pushd gitian-builder
 make -C ../bitcoin/depends download SOURCES_PATH=`pwd`/cache/common
 mkdir -p inputs
 wget -P inputs https://bitcoincore.org/cfields/osslsigncode-Backports-to-1.7.1.patch
-wget -O osslsigncode-2.0.tar.gz -P inputs https://github.com/mtrojnar/osslsigncode/archive/2.0.tar.gz
+wget -O inputs/osslsigncode-2.0.tar.gz https://github.com/mtrojnar/osslsigncode/archive/2.0.tar.gz
 wget -P inputs https://downloads.sourceforge.net/project/osslsigncode/osslsigncode/osslsigncode-1.7.1.tar.gz
 wget -P inputs https://bitcoincore.org/depends-sources/sdks/Xcode-11.3.1-11C505-extracted-SDK-with-libcxx-headers.tar.gz
 ```

--- a/gitian-building.md
+++ b/gitian-building.md
@@ -111,7 +111,7 @@ make -C ../bitcoin/depends download SOURCES_PATH=`pwd`/cache/common
 mkdir -p inputs
 wget -P inputs https://bitcoincore.org/cfields/osslsigncode-Backports-to-1.7.1.patch
 wget -O inputs/osslsigncode-2.0.tar.gz https://github.com/mtrojnar/osslsigncode/archive/2.0.tar.gz
-wget -P inputs https://downloads.sourceforge.net/project/osslsigncode/osslsigncode/osslsigncode-1.7.1.tar.gz
+wget -P inputs https://github.com/bitcoin/bitcoin/files/6175295/osslsigncode-1.7.1.tar.gz
 wget -P inputs https://bitcoincore.org/depends-sources/sdks/Xcode-11.3.1-11C505-extracted-SDK-with-libcxx-headers.tar.gz
 ```
 


### PR DESCRIPTION
### `osslsigncode-2.0.tar.gz`

The `-O` flag holds precedence over the `-P` flag and defaults the location to `./<-O value>`. This fix places the 'inputs' dir directly into the `-O` flag value and removes the `-P` flag for the `osslsigncode-2.0.tar.gz` file.

### `osslsigncode-1.7.1.tar.gz`

Original link is now broken but there is now a version hosted on the `bitcoin` repo (see https://github.com/bitcoin/bitcoin/issues/21416#issuecomment-803286481)
