### PR TITLE
Fix minor github / git issues

### DIFF
--- a/gitian-building.md
+++ b/gitian-building.md
@@ -93,7 +93,7 @@ Fork and clone a copy of the
 
 ```bash
 # After forking https://github.com/bitcoin-core/gitian.sigs on GitHub
-git clone https://github.com/your_github_username/gitian.sigs.git
+git clone git@github.com:your_github_username/gitian.sigs.git
 ```
 
 Clone the other required repositories.
@@ -260,7 +260,7 @@ popd
 pushd gitian.sigs
 git add .
 git commit -m "$SIGNER $VERSION unsigned"
-git push
+git push -u origin $SIGNER-$VERSION-unsigned
 popd
 ```
 


### PR DESCRIPTION
1) Github requires cloning via SSH not HTTPS for write access;
2) simple `git push` for a new local branch will give fatal error about no matching upstream branch.